### PR TITLE
reduced number of std::vector ctor calls

### DIFF
--- a/include/pfasst/sweeper/sweeper.hpp
+++ b/include/pfasst/sweeper/sweeper.hpp
@@ -71,7 +71,7 @@ namespace pfasst
       Sweeper<SweeperTrait, Enabled>& operator=(Sweeper<SweeperTrait, Enabled>&& other) = default;
 
       virtual       shared_ptr<IQuadrature<typename SweeperTrait::time_type>>& quadrature();
-      virtual const shared_ptr<IQuadrature<typename SweeperTrait::time_type>>  get_quadrature() const;
+      virtual const shared_ptr<IQuadrature<typename SweeperTrait::time_type>> get_quadrature() const;
 
       virtual       shared_ptr<Status<typename SweeperTrait::time_type>>& status();
       virtual const shared_ptr<Status<typename SweeperTrait::time_type>>  get_status() const;
@@ -84,11 +84,11 @@ namespace pfasst
       virtual       vector<shared_ptr<typename SweeperTrait::encap_type>>& tau();
 
       virtual const shared_ptr<typename SweeperTrait::encap_type>          get_initial_state() const;
-      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>  get_states() const;
-      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>  get_previous_states() const;
+      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>& get_states() const;
+      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>& get_previous_states() const;
       virtual const shared_ptr<typename SweeperTrait::encap_type>          get_end_state() const;
-      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>  get_tau() const;
-      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>  get_residuals() const;
+      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>& get_tau() const;
+      virtual const vector<shared_ptr<typename SweeperTrait::encap_type>>& get_residuals() const;
 
       virtual       void  set_logger_id(const string& logger_id);
       virtual const char* get_logger_id() const;

--- a/src/pfasst/sweeper/sweeper_impl.hpp
+++ b/src/pfasst/sweeper/sweeper_impl.hpp
@@ -99,7 +99,7 @@ namespace pfasst
   }
 
   template<class SweeperTrait, typename Enabled>
-  const vector<shared_ptr<typename SweeperTrait::encap_type>>
+  const vector<shared_ptr<typename SweeperTrait::encap_type>>&
   Sweeper<SweeperTrait, Enabled>::get_states() const
   {
     return this->_states;
@@ -113,7 +113,7 @@ namespace pfasst
   }
 
   template<class SweeperTrait, typename Enabled>
-  const vector<shared_ptr<typename SweeperTrait::encap_type>>
+  const vector<shared_ptr<typename SweeperTrait::encap_type>>&
   Sweeper<SweeperTrait, Enabled>::get_previous_states() const
   {
     return this->_previous_states;
@@ -141,7 +141,7 @@ namespace pfasst
   }
 
   template<class SweeperTrait, typename Enabled>
-  const vector<shared_ptr<typename SweeperTrait::encap_type>>
+  const vector<shared_ptr<typename SweeperTrait::encap_type>>&
   Sweeper<SweeperTrait, Enabled>::get_tau() const
   {
     return this->_tau;
@@ -155,7 +155,7 @@ namespace pfasst
   }
 
   template<class SweeperTrait, typename Enabled>
-  const vector<shared_ptr<typename SweeperTrait::encap_type>>
+  const vector<shared_ptr<typename SweeperTrait::encap_type>>&
   Sweeper<SweeperTrait, Enabled>::get_residuals() const
   {
     return this->_residuals;


### PR DESCRIPTION
Profiling with valgrind/callgrind showed that much time was burned by copy ctors for std::vector. These calls happened as many of the Sweeper::get_\* methods return copies instead of references.

My test_case was the following:

advec_diff_mlsdc --dt 0.1 --tend 0.5 --num_iters 30 --abs_res_tol 1e-10

I was able to reduce the number of calls from 41042 to 11687 and the time cost of these calls from 10.39% of the total run time to 1.00%.
