### PR TITLE
add mpi_const_cast to save us from all those #ifdefs

### DIFF
--- a/include/pfasst/comm/mpi_p2p.hpp
+++ b/include/pfasst/comm/mpi_p2p.hpp
@@ -21,6 +21,27 @@ using namespace std;
 #include "pfasst/controller/status.hpp"
 
 
+#ifndef NON_CONST_MPI
+  template<typename T>
+  T* mpi_const_cast(const T* input) {
+      return const_cast<T*>(input);
+  }
+  template<typename T>
+  T& mpi_const_cast(const T& input) {
+      return const_cast<T&>(input);
+  }
+#else
+  template<typename T>
+  const T* mpi_const_cast(const T* input) {
+      return input;
+  }
+  template<typename T>
+  const T& mpi_const_cast(const T& input) {
+      return input;
+  }
+#endif
+
+
 namespace pfasst
 {
   namespace comm

--- a/src/pfasst/comm/mpi_p2p_impl.hpp
+++ b/src/pfasst/comm/mpi_p2p_impl.hpp
@@ -132,11 +132,7 @@ namespace pfasst
     void MpiP2P::send(const double* const data, const int count, const int dest_rank, const int tag)
     {
       CLOG(DEBUG, "COMM_P2P") << "sending " << count << " double values with tag=" << tag << " to " << dest_rank;
-#ifdef NON_CONST_MPI
-      int err = MPI_Send(data, count, MPI_DOUBLE, dest_rank, tag, const_cast<MPI_Comm>(this->_comm));
-#else
-      int err = MPI_Send(data, count, MPI_DOUBLE, dest_rank, tag, this->_comm);
-#endif
+      int err = MPI_Send(data, count, MPI_DOUBLE, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm));
       check_mpi_error(err);
     }
 
@@ -145,11 +141,7 @@ namespace pfasst
       assert(pfasst::status_data_type != MPI_DATATYPE_NULL);
 
       CLOG(DEBUG, "COMM_P2P") << "sending " << count << " Status with tag=" << tag << " to " << dest_rank;
-#ifdef NON_CONST_MPI
-      int err = MPI_Send(data, count, status_data_type, dest_rank, tag, const_cast<MPI_Comm>(this->_comm));
-#else
-      int err = MPI_Send(data, count, status_data_type, dest_rank, tag, this->_comm);
-#endif
+      int err = MPI_Send(data, count, status_data_type, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm));
       check_mpi_error(err);
     }
 
@@ -173,11 +165,7 @@ namespace pfasst
         this->_requests.insert(make_pair(request_index, this_request));
       }
 
-#ifdef NON_CONST_MPI
-      int err = MPI_Isend(data, count, MPI_DOUBLE, dest_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
-#else
-      int err = MPI_Isend(data, count, MPI_DOUBLE, dest_rank, tag, this->_comm, &(this->_requests[request_index]));
-#endif
+      int err = MPI_Isend(data, count, MPI_DOUBLE, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
       check_mpi_error(err);
     }
 
@@ -202,11 +190,7 @@ namespace pfasst
         this->_requests.insert(make_pair(request_index, this_request));
       }
 
-#ifdef NON_CONST_MPI
-      int err = MPI_Isend(data, count, status_data_type, dest_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
-#else
-      int err = MPI_Isend(data, count, status_data_type, dest_rank, tag, this->_comm, &(this->_requests[request_index]));
-#endif
+      int err = MPI_Isend(data, count, status_data_type, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
       check_mpi_error(err);
     }
 
@@ -215,11 +199,7 @@ namespace pfasst
     {
       this->_stati.push_back(MPI_Status_factory());
       CLOG(DEBUG, "COMM_P2P") << "receiving " << count << " double values with tag=" << tag << " from " << dest_rank;
-#ifdef NON_CONST_MPI
-      int err = MPI_Recv(data, count, MPI_DOUBLE, dest_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_stati.back()));
-#else
-      int err = MPI_Recv(data, count, MPI_DOUBLE, dest_rank, tag, this->_comm, &(this->_stati.back()));
-#endif
+      int err = MPI_Recv(data, count, MPI_DOUBLE, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_stati.back()));
       check_mpi_error(err);
       CVLOG(1, "COMM_P2P") << "--> status: " << this->_stati.back();
     }
@@ -230,11 +210,7 @@ namespace pfasst
 
       this->_stati.push_back(MPI_Status_factory());
       CLOG(DEBUG, "COMM_P2P") << "receiving " << count << " Status with tag=" << tag << " from " << dest_rank;
-#ifdef NON_CONST_MPI
-      int err = MPI_Recv(data, count, pfasst::status_data_type, dest_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_stati.back()));
-#else
-      int err = MPI_Recv(data, count, pfasst::status_data_type, dest_rank, tag, this->_comm, &(this->_stati.back()));
-#endif
+      int err = MPI_Recv(data, count, pfasst::status_data_type, dest_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_stati.back()));
       check_mpi_error(err);
       CVLOG(1, "COMM_P2P") << "--> status: " << this->_stati.back();
     }
@@ -259,11 +235,7 @@ namespace pfasst
         this->_requests.insert(make_pair(request_index, this_request));
       }
 
-#ifdef NON_CONST_MPI
-      int err = MPI_Irecv(data, count, MPI_DOUBLE, src_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
-#else
-      int err = MPI_Irecv(data, count, MPI_DOUBLE, src_rank, tag, this->_comm, &(this->_requests[request_index]));
-#endif
+      int err = MPI_Irecv(data, count, MPI_DOUBLE, src_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
       check_mpi_error(err);
     }
 
@@ -288,11 +260,7 @@ namespace pfasst
         this->_requests.insert(make_pair(request_index, this_request));
       }
 
-#ifdef NON_CONST_MPI
-      int err = MPI_Irecv(data, count, status_data_type, src_rank, tag, const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
-#else
-      int err = MPI_Irecv(data, count, status_data_type, src_rank, tag, this->_comm, &(this->_requests[request_index]));
-#endif
+      int err = MPI_Irecv(data, count, status_data_type, src_rank, tag, mpi_const_cast<MPI_Comm>(this->_comm), &(this->_requests[request_index]));
       check_mpi_error(err);
     }
 
@@ -300,11 +268,7 @@ namespace pfasst
     void MpiP2P::bcast(double* data, const int count, const int root_rank)
     {
       CLOG(DEBUG, "COMM_P2P") << "braodcasting " << count << " double values from root " << root_rank;
-#ifdef NON_CONST_MPI
-      int err = MPI_Bcast(data, count, MPI_DOUBLE, root_rank, const_cast<MPI_Comm>(this->_comm));
-#else
-      int err = MPI_Bcast(data, count, MPI_DOUBLE, root_rank, this->_comm);
-#endif
+      int err = MPI_Bcast(data, count, MPI_DOUBLE, root_rank, mpi_const_cast<MPI_Comm>(this->_comm));
       check_mpi_error(err);
     }
   }


### PR DESCRIPTION
Added a conditional const_cast operation to work around the lacking const awareness of MPI
