### PR TITLE
Feature/fix virtual

### DIFF
--- a/examples/advec_diff/advec_diff_sweeper.hpp
+++ b/examples/advec_diff/advec_diff_sweeper.hpp
@@ -81,7 +81,7 @@ namespace pfasst
 
           virtual bool converged() override;
 
-          virtual size_t get_num_dofs() const;
+          size_t get_num_dofs() const;
       };
     }  // ::pfasst::examples::advec_diff
   }  // ::pfasst::examples

--- a/examples/heat1d/heat1d_sweeper.hpp
+++ b/examples/heat1d/heat1d_sweeper.hpp
@@ -74,7 +74,7 @@ namespace pfasst
 
           virtual bool converged() override;
 
-          virtual size_t get_num_dofs() const;
+          size_t get_num_dofs() const;
       };
     }  // ::pfasst::examples::heat1d
   }  // ::pfasst::examples


### PR DESCRIPTION
This solves the problem that a lot of time is wasted in `get_num_dofs()` because of vtable lookup.
