### PR TITLE
removed bad virtuals

### DIFF
--- a/examples/advec_diff/advec_diff_sweeper.hpp
+++ b/examples/advec_diff/advec_diff_sweeper.hpp
@@ -81,7 +81,7 @@ namespace pfasst
 
           virtual bool converged() override;
 
-          virtual size_t get_num_dofs() const;
+          size_t get_num_dofs() const;
       };
     }  // ::pfasst::examples::advec_diff
   }  // ::pfasst::examples

--- a/examples/heat1d/heat1d_sweeper.hpp
+++ b/examples/heat1d/heat1d_sweeper.hpp
@@ -74,7 +74,7 @@ namespace pfasst
 
           virtual bool converged() override;
 
-          virtual size_t get_num_dofs() const;
+          size_t get_num_dofs() const;
       };
     }  // ::pfasst::examples::heat1d
   }  // ::pfasst::examples


### PR DESCRIPTION
`get_num_dofs()` should not be virtual. It is not necessary but hramful as the function is called frequently.
